### PR TITLE
Revert fixed header

### DIFF
--- a/src/Spout/Writer/XLSX/Internal/Worksheet.php
+++ b/src/Spout/Writer/XLSX/Internal/Worksheet.php
@@ -118,8 +118,7 @@ EOD;
                 );
             }
         }
-
-        fwrite($this->sheetFilePointer, self::SHEET_VIEW_XML_DATA);
+        
         fwrite($this->sheetFilePointer, '<sheetData>');
     }
 


### PR DESCRIPTION
Reverting fixed header to solve problems on production after export excel file. Office 2016 and 2019 not support this changes